### PR TITLE
Fix alignment of files and folders in book search tree

### DIFF
--- a/lib/screens/book_tree_checklist.dart
+++ b/lib/screens/book_tree_checklist.dart
@@ -45,7 +45,7 @@ class FileTreeViewScreenState extends State<FileTreeViewScreen> {
       key: Key(directory.path), // Ensure unique keys for ExpansionTiles
       title: Text(path.basename(directory.path)),
 
-      tilePadding: EdgeInsets.symmetric(horizontal: 16 + level * 16),
+      tilePadding: EdgeInsets.symmetric(horizontal: 16 + (level-1) * 16),
       leading: SizedBox.fromSize(
         size: const Size.fromWidth(60.0),
         child: Row(


### PR DESCRIPTION
Previously, the book tree checklist screen was incorrectly calculating the horizontal padding for items by only considering the current nesting level. This resulted in misaligned titles.

This commit updates the logic to use (level - 1) when computing the left padding amount. By subtracting one from the item's level, the padding is adjusted to ensure each item is properly indented based on its hierarchy in the tree.

The level-minus-one approach fixes the alignment issues and provides a cleaner, more intuitive layout of parent/child items in the checklist.

Closes #50 