### PR TITLE
fix: upgrade archive dependency for flutter 3.5.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.10"
+    version: "3.6.1"
   args:
     dependency: transitive
     description:


### PR DESCRIPTION
Flutter 3.5.0 removed some tapes, so we need to upgrade the `archive` dependency so that the project can be built under the latest stable version of flutter.

https://github.com/jonataslaw/get_cli/issues/263#issuecomment-2273260052
https://github.com/brendan-duncan/archive/issues/350, https://github.com/brendan-duncan/archive/issues/346