### PR TITLE
chore: create conventional-pr-title.yml

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -1,0 +1,44 @@
+name: "Conventional PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+            
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+            Details:
+            
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
Enforcing Conventional Commits in the PRs title using https://github.com/amannn/action-semantic-pull-request. Using Conventional Commits makes the change history and intent clearer, especially in the long run. It also allows the creation of a changelog divided into sections (feat, fix, etc.) automatically by GitHub when creating a release.

Refs:
https://www.conventionalcommits.org/en/v1.0.0/
https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13

The workflow is copied from https://github.com/filebrowser/filebrowser/blob/master/.github/workflows/pr-lint.yaml, you can see this an it in action [here](https://github.com/filebrowser/filebrowser/pull/3235#issuecomment-2119115874).