### PR TITLE
feat: Support local Hebrewbooks  PDF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/lib/data/repository/data_repository.dart
+++ b/lib/data/repository/data_repository.dart
@@ -45,9 +45,9 @@ class DataRepository {
 
   /// Retrieves the list of books from the Hebrew Books project
   ///
-  /// Returns a [Future] that completes with a list of [ExternalBook] objects
+  /// Returns a [Future] that completes with a list of [Book] objects
   /// representing books from the Hebrew Books collection
-  Future<List<ExternalBook>> getHebrewBooks() {
+  Future<List<Book>> getHebrewBooks() {
     return FileSystemData.getHebrewBooks();
   }
 

--- a/lib/models/app_model.dart
+++ b/lib/models/app_model.dart
@@ -51,7 +51,7 @@ class AppModel with ChangeNotifier {
   late Future<List<ExternalBook>> otzarBooks;
 
   /// Future containing the list of books from HebrewBooks
-  late Future<List<ExternalBook>> hebrewBooks;
+  late Future<List<Book>> hebrewBooks;
 
   /// List of currently opened tabs in the application
   List<OpenedTab> tabs = [];

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -240,7 +240,7 @@ class _MySettingsScreenState extends State<MySettingsScreen>
                   titleAlignment: Alignment.centerRight,
                   titleTextStyle: const TextStyle(fontSize: 25),
                   children: [
-                    SwitchSettingsTile(
+                    const SwitchSettingsTile(
                       title: 'סינכרון אוטומטי',
                       leading: Icon(Icons.sync),
                       settingKey: 'key-auto-sync',
@@ -248,7 +248,7 @@ class _MySettingsScreenState extends State<MySettingsScreen>
                       enabledLabel: 'מאגר הספרים יתעדכן אוטומטית',
                       disabledLabel: 'מאגר הספרים לא יתעדכן אוטומטית.',
                     ),
-                    if (!(Platform.isAndroid || Platform.isIOS))
+                    if (!(Platform.isAndroid || Platform.isIOS)) ...[
                       SimpleSettingsTile(
                         title: 'מיקום הספרייה',
                         subtitle:
@@ -264,7 +264,25 @@ class _MySettingsScreenState extends State<MySettingsScreen>
                           }
                         },
                       ),
-                    const SwitchSettingsTile(
+                      SimpleSettingsTile(
+                        title: 'מיקום ספרי HebrewBooks',
+                        subtitle: Settings.getValue<String>(
+                                'key-hebrew-books-path') ??
+                            'לא קיים',
+                        leading: const Icon(Icons.folder),
+                        onTap: () async {
+                          String? path =
+                              await FilePicker.platform.getDirectoryPath();
+                          if (path != null) {
+                            Settings.setValue<String>(
+                                'key-hebrew-books-path', path);
+
+                            context.read<AppModel>().refreshLibrary();
+                          }
+                        },
+                      ),
+                    ],
+                    SwitchSettingsTile(
                       settingKey: 'key-dev-channel',
                       title: 'עדכון לגרסאות מפתחים',
                       enabledLabel:
@@ -290,7 +308,7 @@ class _MySettingsScreenState extends State<MySettingsScreen>
                               leading: Icon(Icons.info_rounded),
                             ),
                           );
-                        })
+                        }),
                   ],
                 )
               ],


### PR DESCRIPTION
Implements #291 

Note: 
You need to enable to show external/HebrewBooks in the settings (not sure if we should leave it like this for now or not)..

- Enhanced the `_getHebrewBooks` method to differentiate between local and external books, adding support for local PDF files.
-
- Added a new settings option for specifying the local path of HebrewBooks.


