### PR TITLE
fix: Preserve PDF search results across sidebar tab switches and reopen

### DIFF
--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -379,16 +379,17 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                 Row(
                   children: [
                     Expanded(
-                      child: ClipRect(
-                        child: TabBar(
-
-                          controller: _leftPaneTabController, // Use the managed controller
-
-                          tabs: const [
-                            Tab(text: 'ניווט'),
-                            Tab(text: 'חיפוש'),
-                            Tab(text: 'דפים'),
-                          ],
+                      child: Material(
+                        color: Colors.transparent,
+                        child: ClipRect(
+                          child: TabBar(
+                            controller: _leftPaneTabController, // Use the managed controller
+                            tabs: const [
+                              Tab(text: 'ניווט'),
+                              Tab(text: 'חיפוש'),
+                              Tab(text: 'דפים'),
+                            ],
+                          ),
                         ),
                       ),
                     ),

--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -423,10 +423,21 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                       ),
                       ValueListenableBuilder(
                         valueListenable: widget.tab.documentRef,
-                        builder: (context, documentRef, child) => child!,
+                        builder: (context, documentRef, child) {
+                          // Check if PdfBookSearchView will trigger an initial search
+                          if (widget.tab.searchController.text.isNotEmpty) {
+                            // If there's text in the search controller, it implies that
+                            // PdfBookSearchView.initState will trigger an initial search.
+                            // We reset _lastProcessedSearchSessionId here
+                            // to ensure that the completion of this initial search is unequivocally
+                            // treated as a new search session by the _onTextSearcherUpdated listener.
+                            _lastProcessedSearchSessionId = null;
+                          }
+                          return child!;
+                        },
                         child: PdfBookSearchView(
                           textSearcher: textSearcher,
-                          searchController: widget.tab.searchController, // Added
+                          searchController: widget.tab.searchController,
                           initialSearchText: widget.tab.searchText,
                           onSearchResultNavigated: _ensureSearchTabIsActive,
                         ),

--- a/lib/pdf_book/pdf_book_screen.dart
+++ b/lib/pdf_book/pdf_book_screen.dart
@@ -51,36 +51,27 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   final GlobalKey<State<PdfBookSearchView>> _searchViewKey = GlobalKey();
 
   void _onTextSearcherUpdated() {
-    // Store current search term from textSearcher to compare later
-    String? previousSearchTextInTab = widget.tab.searchText;
-    int? previousMatchIndexInTab = widget.tab.pdfSearchCurrentMatchIndex;
+    String currentSearchTerm = widget.tab.searchController.text;
+    // Capture the potentially persisted index BEFORE updating the tab's state
+    int? previousPersistedIndex = widget.tab.pdfSearchCurrentMatchIndex;
 
-    // Update tab with current state from textSearcher
-    widget.tab.searchText = textSearcher.searchText ?? "";
-    widget.tab.pdfSearchMatches = List.from(textSearcher.matches); // Important: store a copy
+    // Update the tab's state from the textSearcher
+    widget.tab.searchText = currentSearchTerm;
+    widget.tab.pdfSearchMatches = List.from(textSearcher.matches);
     widget.tab.pdfSearchCurrentMatchIndex = textSearcher.currentIndex;
 
     if (mounted) {
-      setState(() {}); // Original purpose of _update
+      setState(() {});
     }
 
-    // Logic to restore current index if this update is for the persisted search term
-    // This executes after textSearcher has finished a search (e.g., from PdfBookSearchView's initState)
-    // and notified its listeners (which calls this function).
-    if (textSearcher.searchText.isNotEmpty &&
-        textSearcher.searchText == previousSearchTextInTab && // check if search text is same as what was in tab
+    // Logic to restore currentIndex using previousPersistedIndex
+    if (currentSearchTerm.isNotEmpty &&
         textSearcher.matches.isNotEmpty &&
-        previousMatchIndexInTab != null &&
-        previousMatchIndexInTab >= 0 &&
-        previousMatchIndexInTab < textSearcher.matches.length &&
-        textSearcher.currentIndex != previousMatchIndexInTab) {
-      // Prevent re-entry or ensure it's safe if goToMatchOfIndex notifies synchronously
-      // For pdfrx, goToMatchOfIndex might update currentIndex and notify.
-      // The condition `textSearcher.currentIndex != previousMatchIndexInTab` should make this safe.
-      textSearcher.goToMatchOfIndex(previousMatchIndexInTab);
-      // After this, _onTextSearcherUpdated will be called again.
-      // On the next call, previousMatchIndexInTab (from widget.tab) will be equal to textSearcher.currentIndex,
-      // so this block won't re-execute, preventing a loop.
+        previousPersistedIndex != null &&
+        previousPersistedIndex >= 0 &&
+        previousPersistedIndex < textSearcher.matches.length &&
+        textSearcher.currentIndex != previousPersistedIndex) {
+      textSearcher.goToMatchOfIndex(previousPersistedIndex);
     }
   }
 
@@ -420,11 +411,10 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                         valueListenable: widget.tab.documentRef,
                         builder: (context, documentRef, child) => child!,
                         child: PdfBookSearchView(
-
                           textSearcher: textSearcher,
+                          searchController: widget.tab.searchController, // Added
                           initialSearchText: widget.tab.searchText,
                           onSearchResultNavigated: _ensureSearchTabIsActive,
-
                         ),
                       ),
                       ValueListenableBuilder(

--- a/lib/pdf_book/pdf_outlines_screen.dart
+++ b/lib/pdf_book/pdf_outlines_screen.dart
@@ -115,12 +115,15 @@ class _OutlineViewState extends State<OutlineView> {
         child: node.children.isEmpty
             ? Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  hoverColor: Theme.of(context).hoverColor,
+                child: ListTile(
+                  title: Text(node.title),
+                  // === מה שהיה ב-InkWell עובר לפה ===
                   onTap: navigateToEntry,
-                  child: ListTile(
-                    title: Text(node.title),
-                  ),
+                  hoverColor: Theme.of(context).hoverColor,
+                  mouseCursor: SystemMouseCursors.click,
+                  // אפשרויות נוספות אם צריך:
+                  // dense: true,
+                  // visualDensity: VisualDensity.compact,
                 ),
               )
             : Material(
@@ -128,9 +131,13 @@ class _OutlineViewState extends State<OutlineView> {
                 child: ExpansionTile(
                   key: PageStorageKey(node),
                   initiallyExpanded: level == 0,
-                  title: InkWell(
+                  // גם לכותרת של הצומת המורחב נוסיף ListTile
+                  title: ListTile(
+                    title: Text(node.title),
                     onTap: navigateToEntry,
-                    child: Text(node.title),
+                    hoverColor: Theme.of(context).hoverColor,
+                    mouseCursor: SystemMouseCursors.click,
+                    contentPadding: EdgeInsets.zero, // שלא יזיז ימינה
                   ),
                   leading: const Icon(Icons.chevron_right_rounded),
                   trailing: const SizedBox.shrink(),
@@ -139,8 +146,7 @@ class _OutlineViewState extends State<OutlineView> {
                   iconColor: Theme.of(context).colorScheme.primary,
                   collapsedIconColor: Theme.of(context).colorScheme.primary,
                   children: node.children
-                      .map((childNode) =>
-                          _buildOutlineItem(childNode, level: level + 1))
+                      .map((c) => _buildOutlineItem(c, level: level + 1))
                       .toList(),
                 ),
               ),

--- a/lib/pdf_book/pdf_outlines_screen.dart
+++ b/lib/pdf_book/pdf_outlines_screen.dart
@@ -19,6 +19,32 @@ class _OutlineViewState extends State<OutlineView> {
   TextEditingController searchController = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant OutlineView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onControllerChanged);
+      widget.controller.addListener(_onControllerChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onControllerChanged);
+    searchController.dispose();
+    super.dispose();
+  }
+
+  void _onControllerChanged() {
+    if (mounted) setState(() {});
+  }
+
+  @override
   Widget build(BuildContext context) {
     final outline = widget.outline;
     if (outline == null || outline.isEmpty) {
@@ -117,13 +143,15 @@ class _OutlineViewState extends State<OutlineView> {
                 color: Colors.transparent,
                 child: ListTile(
                   title: Text(node.title),
-                  // === מה שהיה ב-InkWell עובר לפה ===
+                  selected: widget.controller.isReady &&
+                      node.dest?.pageNumber ==
+                          widget.controller.pageNumber,
+                  selectedColor: Theme.of(context).colorScheme.onSecondary,
+                  selectedTileColor:
+                      Theme.of(context).colorScheme.secondary.withOpacity(0.2),
                   onTap: navigateToEntry,
                   hoverColor: Theme.of(context).hoverColor,
                   mouseCursor: SystemMouseCursors.click,
-                  // אפשרויות נוספות אם צריך:
-                  // dense: true,
-                  // visualDensity: VisualDensity.compact,
                 ),
               )
             : Material(
@@ -134,6 +162,15 @@ class _OutlineViewState extends State<OutlineView> {
                   // גם לכותרת של הצומת המורחב נוסיף ListTile
                   title: ListTile(
                     title: Text(node.title),
+                    selected: widget.controller.isReady &&
+                        node.dest?.pageNumber ==
+                            widget.controller.pageNumber,
+                    selectedColor:
+                        Theme.of(context).colorScheme.onSecondary,
+                    selectedTileColor: Theme.of(context)
+                        .colorScheme
+                        .secondary
+                        .withOpacity(0.2),
                     onTap: navigateToEntry,
                     hoverColor: Theme.of(context).hoverColor,
                     mouseCursor: SystemMouseCursors.click,

--- a/lib/pdf_book/pdf_outlines_screen.dart
+++ b/lib/pdf_book/pdf_outlines_screen.dart
@@ -113,30 +113,36 @@ class _OutlineViewState extends State<OutlineView> {
           dividerColor: Colors.transparent,
         ),
         child: node.children.isEmpty
-            ? InkWell(
-              hoverColor: Theme.of(context).hoverColor,
-              child: ListTile(
-                title: Text(node.title),
-                onTap: navigateToEntry,
-              ),
-            )
-            : ExpansionTile(
-                key: PageStorageKey(node),
-                initiallyExpanded: level == 0,
-                title: InkWell(
+            ? Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  hoverColor: Theme.of(context).hoverColor,
                   onTap: navigateToEntry,
-                  child: Text(node.title),
+                  child: ListTile(
+                    title: Text(node.title),
+                  ),
                 ),
-                leading: const Icon(Icons.chevron_right_rounded),
-                trailing: const SizedBox.shrink(),
-                tilePadding: EdgeInsets.zero,
-                childrenPadding: EdgeInsets.zero,
-                iconColor: Theme.of(context).colorScheme.primary,
-                collapsedIconColor: Theme.of(context).colorScheme.primary,
-                children: node.children
-                    .map((childNode) =>
-                        _buildOutlineItem(childNode, level: level + 1))
-                    .toList(),
+              )
+            : Material(
+                color: Colors.transparent,
+                child: ExpansionTile(
+                  key: PageStorageKey(node),
+                  initiallyExpanded: level == 0,
+                  title: InkWell(
+                    onTap: navigateToEntry,
+                    child: Text(node.title),
+                  ),
+                  leading: const Icon(Icons.chevron_right_rounded),
+                  trailing: const SizedBox.shrink(),
+                  tilePadding: EdgeInsets.zero,
+                  childrenPadding: EdgeInsets.zero,
+                  iconColor: Theme.of(context).colorScheme.primary,
+                  collapsedIconColor: Theme.of(context).colorScheme.primary,
+                  children: node.children
+                      .map((childNode) =>
+                          _buildOutlineItem(childNode, level: level + 1))
+                      .toList(),
+                ),
               ),
       ),
     );

--- a/lib/pdf_book/pdf_search_screen.dart
+++ b/lib/pdf_book/pdf_search_screen.dart
@@ -9,15 +9,15 @@ import 'package:synchronized/extension.dart';
 class PdfBookSearchView extends StatefulWidget {
   const PdfBookSearchView({
     required this.textSearcher,
+    required this.searchController,
     this.initialSearchText = '',
-
     this.onSearchResultNavigated, // Add this
-
     super.key,
   });
 
   final PdfTextSearcher textSearcher;
-  final String initialSearchText;
+  final TextEditingController searchController;
+  final String initialSearchText; // Remains for now, parent will provide tab.searchText
 
   final VoidCallback? onSearchResultNavigated; // Add this
 
@@ -28,37 +28,38 @@ class PdfBookSearchView extends StatefulWidget {
 
 class _PdfBookSearchViewState extends State<PdfBookSearchView> {
   final focusNode = FocusNode();
-  final searchTextController = TextEditingController();
+  // final searchTextController = TextEditingController(); // Removed
   late final pageTextStore =
       PdfPageTextCache(textSearcher: widget.textSearcher);
   final scrollController = ScrollController();
   @override
   void initState() {
+    super.initState(); // Moved to the top
     widget.textSearcher.addListener(_searchResultUpdated);
-    searchTextController.addListener(_searchTextUpdated);
-    
-    // Set initial search text if provided
-    if (widget.initialSearchText.isNotEmpty) {
-      searchTextController.text = widget.initialSearchText;
-      // Start the search but don't navigate if shouldNavigateOnInitialSearch is false
+    widget.searchController.addListener(_searchTextUpdated);
 
+    // If the controller (from PdfBookTab) already has text when view is initialized,
+    // start the search. This ensures that if the sidebar is reopened with existing
+    // search text, the search is re-executed and results are displayed.
+    if (widget.searchController.text.isNotEmpty) {
+      // We pass goToFirstMatch: false because the _onTextSearcherUpdated listener
+      // in _PdfBookScreenState is responsible for restoring the specific currentIndex later.
+      widget.textSearcher.startTextSearch(widget.searchController.text, goToFirstMatch: false);
     }
-    
-    super.initState();
   }
 
   @override
   void dispose() {
     scrollController.dispose();
     widget.textSearcher.removeListener(_searchResultUpdated);
-    searchTextController.removeListener(_searchTextUpdated);
-    searchTextController.dispose();
+    widget.searchController.removeListener(_searchTextUpdated); // Changed
+    // searchTextController.dispose(); // Removed
     focusNode.dispose();
     super.dispose();
   }
 
   void _searchTextUpdated() {
-    widget.textSearcher.startTextSearch(searchTextController.text, goToFirstMatch: false);
+    widget.textSearcher.startTextSearch(widget.searchController.text, goToFirstMatch: false); // Changed
   }
 
   int? _currentSearchSession;
@@ -144,7 +145,7 @@ class _PdfBookSearchViewState extends State<PdfBookSearchView> {
                   TextField(
                     autofocus: true,
                     focusNode: focusNode,
-                    controller: searchTextController,
+                    controller: widget.searchController, // Changed
                     decoration: const InputDecoration(
                       contentPadding: EdgeInsets.only(right: 50),
                     ),
@@ -195,9 +196,9 @@ class _PdfBookSearchViewState extends State<PdfBookSearchView> {
               iconSize: 20,
             ),
             IconButton(
-              onPressed: searchTextController.text.isNotEmpty
+              onPressed: widget.searchController.text.isNotEmpty // Changed
                   ? () {
-                      searchTextController.text = '';
+                      widget.searchController.text = ''; // Changed
                       widget.textSearcher.resetTextSearch();
                       focusNode.requestFocus();
                     }
@@ -210,7 +211,7 @@ class _PdfBookSearchViewState extends State<PdfBookSearchView> {
         const SizedBox(height: 4),
         Expanded(
           child: ListView.builder(
-            key: Key(searchTextController.text),
+            key: Key(widget.searchController.text), // Changed
             controller: scrollController,
             itemCount: _listIndexToMatchIndex.length,
             itemBuilder: (context, index) {

--- a/lib/pdf_book/pdf_search_screen.dart
+++ b/lib/pdf_book/pdf_search_screen.dart
@@ -45,6 +45,7 @@ class _PdfBookSearchViewState extends State<PdfBookSearchView> {
       // We pass goToFirstMatch: false because the _onTextSearcherUpdated listener
       // in _PdfBookScreenState is responsible for restoring the specific currentIndex later.
       widget.textSearcher.startTextSearch(widget.searchController.text, goToFirstMatch: false);
+      _searchResultUpdated();
     }
   }
 

--- a/lib/tabs/models/pdf_tab.dart
+++ b/lib/tabs/models/pdf_tab.dart
@@ -27,6 +27,9 @@ class PdfBookTab extends OpenedTab {
 
   final String searchText;
 
+  List<PdfTextRangeWithFragments>? pdfSearchMatches;
+  int? pdfSearchCurrentMatchIndex;
+
   final currentTitle = ValueNotifier<String>("");
 
   ///a flag that tells if the left pane should be shown
@@ -39,12 +42,14 @@ class PdfBookTab extends OpenedTab {
   ///
   /// The [book] parameter represents the PDF book, and the [pageNumber]
   /// parameter represents the current page number.
-  PdfBookTab(
-      {required this.book,
-      required this.pageNumber,
-      bool openLeftPane = false,
-      this.searchText = ''})
-      : super(book.title) {
+  PdfBookTab({
+    required this.book,
+    required this.pageNumber,
+    bool openLeftPane = false,
+    this.searchText = '',
+    this.pdfSearchMatches,
+    this.pdfSearchCurrentMatchIndex,
+  }) : super(book.title) {
     showLeftPane = ValueNotifier<bool>(openLeftPane);
     searchController.text = searchText;
   }

--- a/lib/tabs/models/pdf_tab.dart
+++ b/lib/tabs/models/pdf_tab.dart
@@ -25,7 +25,7 @@ class PdfBookTab extends OpenedTab {
 
   final TextEditingController searchController = TextEditingController();
 
-  final String searchText;
+  String searchText;
 
   List<PdfTextRangeWithFragments>? pdfSearchMatches;
   int? pdfSearchCurrentMatchIndex;

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -168,10 +168,9 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
             Future.value(currentState.tableOfContents));
       }
 
-      int? index = currentState.selectedIndex;
-      if (!event.visibleIndecies.contains(index)) {
-        index = null;
-      }
+      int? index = event.visibleIndecies.isNotEmpty
+          ? event.visibleIndecies.first
+          : currentState.selectedIndex;
 
       emit(currentState.copyWith(
           visibleIndices: event.visibleIndecies,

--- a/lib/text_book/view/toc_navigator_screen.dart
+++ b/lib/text_book/view/toc_navigator_screen.dart
@@ -83,9 +83,19 @@ class _TocViewerState extends State<TocViewer>
     if (entry.children.isEmpty) {
       return Padding(
         padding: EdgeInsets.fromLTRB(0, 0, 10 * entry.level.toDouble(), 0),
-        child: ListTile(
-          title: Text(entry.text),
-          onTap: navigateToEntry,
+        child: BlocBuilder<TextBookBloc, TextBookState>(
+          builder: (context, state) {
+            final bool selected = state is TextBookLoaded &&
+                state.selectedIndex == entry.index;
+            return ListTile(
+              title: Text(entry.text),
+              selected: selected,
+              selectedColor: Theme.of(context).colorScheme.onSecondary,
+              selectedTileColor:
+                  Theme.of(context).colorScheme.secondary.withOpacity(0.2),
+              onTap: navigateToEntry,
+            );
+          },
         ),
       );
     } else {
@@ -97,9 +107,23 @@ class _TocViewerState extends State<TocViewer>
           ),
           child: ExpansionTile(
             initiallyExpanded: entry.level == 1,
-            title: GestureDetector(
-              onTap: navigateToEntry,
-              child: Text(showFullText ? entry.fullText : entry.text),
+            title: BlocBuilder<TextBookBloc, TextBookState>(
+              builder: (context, state) {
+                final bool selected = state is TextBookLoaded &&
+                    state.selectedIndex == entry.index;
+                return ListTile(
+                  title: Text(showFullText ? entry.fullText : entry.text),
+                  selected: selected,
+                  selectedColor:
+                      Theme.of(context).colorScheme.onSecondary,
+                  selectedTileColor: Theme.of(context)
+                      .colorScheme
+                      .secondary
+                      .withOpacity(0.2),
+                  onTap: navigateToEntry,
+                  contentPadding: EdgeInsets.zero,
+                );
+              },
             ),
             leading: const Icon(Icons.chevron_right_rounded),
             trailing: const SizedBox.shrink(),


### PR DESCRIPTION
### Bug Description
When performing a search in a PDF (via the sidebar's 'Search' tab), the list of search results is displayed correctly.

However, if the sidebar is closed and reopened, the search term remains (this was previously handled), but the search results list disappears.  
A similar issue also occurs when switching between sidebar tabs — for example, moving from 'Search' to 'Navigation' or 'Pages', and then returning to 'Search'.

### Fix Summary
This PR ensures that the search results persist across sidebar state changes, including:
- Closing and reopening the sidebar
- Switching between tabs inside the sidebar

### Notes
This bug persisted despite earlier commits attempting to resolve it. The fix here ensures full state preservation for both the search term and its results.


לדוברי העברית:

### תיאור התקלה
בעת חיפוש בקובץ PDF (באמצעות סרגל הצד בכרטיסיית 'חיפוש'), מתקבלת רשימת תוצאות חיפוש כמצופה.

אך כאשר סוגרים את סרגל הצד ופותחים אותו מחדש — מילות החיפוש נשמרות (טופל בקומיטים קודמים), אך **רשימת התוצאות נעלמת**.  
אותה תקלה מתרחשת גם כאשר לא סוגרים את הסרגל, אלא רק עוברים בכרטיסיות הפנימיות שלו (למשל ל'ניווט' או 'דפים') וחוזרים ל'חיפוש'.

### סיכום התיקון
תיקון זה שומר את מצב התוצאות בכל אחד מהמקרים הבאים:
- סגירה ופתיחה מחדש של סרגל הצד
- מעבר בין כרטיסיות שונות בסרגל

### הערות
הבאג המשיך להתרחש גם לאחר מספר נסיונות תיקון קודמים. התיקון הנוכחי מבטיח שמירה מלאה גם של מילת החיפוש וגם של תוצאותיה.
