### PR TITLE
fix: handle PathNotFoundException for non-existent drives

### DIFF
--- a/lib/utils/otzar_utils.dart
+++ b/lib/utils/otzar_utils.dart
@@ -34,16 +34,15 @@ class OtzarUtils {
 
   static Future<bool> checkBookExistence(int bookId) async {
     for (final drive in _availableDrives) {
-      //newer version teh path is under the /books folder with the extension .book
-      final bookPath = '$drive:\\books\\$bookId.book';
-      final bookFile = File(bookPath);
-      if (await bookFile.exists()) {
-        return true;
-      }
-
-      final zipPath = '$drive:\\zip';
-
       try {
+        //newer version teh path is under the /books folder with the extension .book
+        final bookPath = '$drive:\\books\\$bookId.book';
+        final bookFile = File(bookPath);
+        if (await bookFile.exists()) {
+          return true;
+        }
+
+        final zipPath = '$drive:\\zip';
         final zipDir = Directory(zipPath);
         if (await zipDir.exists()) {
           final bookPath = '$zipPath\\$bookId.ocd';
@@ -53,7 +52,7 @@ class OtzarUtils {
           }
         }
       } catch (e) {
-        // Continue to the next possible drive  if there's an error
+        // Continue to the next possible drive if there's an error (e.g., drive doesn't exist)
         continue;
       }
     }


### PR DESCRIPTION
Fixes issue where Otzaria v0.2.7 fails to open with PathNotFoundException when trying to access non-existent drives like F:\.

The checkBookExistence function in otzar_utils.dart was not properly handling cases where drives don't exist on the system. Added comprehensive error handling to gracefully handle missing drives.

Fixes #643

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling for file and directory checks to ensure smoother operation in cases where drives or files may not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->